### PR TITLE
Set pin as input when configuring interrupt

### DIFF
--- a/Resources/Source_code/Workspace/stm32f4xx_drivers/drivers/src/stm32f407xx_gpio_driver.c
+++ b/Resources/Source_code/Workspace/stm32f4xx_drivers/drivers/src/stm32f407xx_gpio_driver.c
@@ -99,6 +99,9 @@ void GPIO_Init(GPIO_Handle_t *pGPIOHandle)
 
 	}else
 	{
+	        //Configure GPIO as input
+		pGPIOHandle->pGPIOx->MODER &= ~( 0x3 << (2 * pGPIOHandle->GPIO_PinConfig.GPIO_PinNumber));
+		
 		//this part will code later . ( interrupt mode)
 		if(pGPIOHandle->GPIO_PinConfig.GPIO_PinMode ==GPIO_MODE_IT_FT )
 		{


### PR DESCRIPTION
In my microcontroller the pins are started by default as an analog mode (to save energy), so it would be interesting to ensure that the pin is configured as an input before starting the interrupt configuration process.