### PR TITLE
Update stm32f407xx_spi_driver.c

### DIFF
--- a/Resources/Source_code/Workspace/stm32f4xx_drivers/drivers/src/stm32f407xx_spi_driver.c
+++ b/Resources/Source_code/Workspace/stm32f4xx_drivers/drivers/src/stm32f407xx_spi_driver.c
@@ -199,8 +199,9 @@ void SPI_ReceiveData(SPI_RegDef_t *pSPIx, uint8_t *pRxBuffer, uint32_t Len)
 {
 	while(Len > 0)
 		{
-			//1. wait until RXNE is set
-			while(SPI_GetFlagStatus(pSPIx,SPI_RXNE_FLAG)  == (uint8_t)FLAG_RESET );
+			//1. wait until RXNE is reset
+			//while(SPI_GetFlagStatus(pSPIx,SPI_RXNE_FLAG)  == (uint8_t)FLAG_RESET );
+			while(SPI_GetFlagStatus(pSPIx,SPI_RXNE_FLAG)  == (uint8_t)FLAG_SET ); //bug fix: infinite loop bug
 
 			//2. check the DFF bit in CR1
 			if( (pSPIx->CR1 & ( 1 << SPI_CR1_DFF) ) )


### PR DESCRIPTION
When we receive data from slave, the RXNE is SET automatically and to make RXNE = 0 (default value) to continue communication, we dummy read the Rx buffer. So the following lines must be changed **to avoid infinite loop error**. Please do verify and let me know. Thanks

while(SPI_GetFlagStatus(pSPIx,SPI_RXNE_FLAG) == (uint8_t)FLAG_RESET ); //original
while(SPI_GetFlagStatus(pSPIx,SPI_RXNE_FLAG) == (uint8_t)FLAG_SET ) //fix;