### PR TITLE
Fix I2C master RXNE IT timing issue

### DIFF
--- a/Resources/Source_code/Workspace/stm32f4xx_drivers/drivers/src/stm32f407xx_i2c_driver.c
+++ b/Resources/Source_code/Workspace/stm32f4xx_drivers/drivers/src/stm32f407xx_i2c_driver.c
@@ -624,14 +624,27 @@ static void I2C_MasterHandleRXNEInterrupt(I2C_Handle_t *pI2CHandle )
 	{
 		if(pI2CHandle->RxLen == 2)
 		{
+			// wait until  BTF becomes 1
+			while(! I2C_GetSR1FlagStatus(pI2CHandle->pI2Cx, I2C_FLAG_BTF));
+
 			//clear the ack bit
 			I2C_ManageAcking(pI2CHandle->pI2Cx,DISABLE);
-		}
 
+
+			//read DR twice
+			*pI2CHandle->pRxBuffer = pI2CHandle->pI2Cx->DR;
+			pI2CHandle->pRxBuffer++;
+			pI2CHandle->RxLen--;
+			*pI2CHandle->pRxBuffer = pI2CHandle->pI2Cx->DR;
+			pI2CHandle->RxLen--;
+		}
+		else if(pI2CHandle->RxLen > 2)
+		{
 			//read DR
 			*pI2CHandle->pRxBuffer = pI2CHandle->pI2Cx->DR;
 			pI2CHandle->pRxBuffer++;
 			pI2CHandle->RxLen--;
+		}
 	}
 
 	if(pI2CHandle->RxLen == 0 )


### PR DESCRIPTION
The RXNE interrupt handler was not setting the STOP bit at the correct N-1 byte step as required by RM0090. This caused 012i2c_master_rx_testingIT.c to get stuck after the second button press. Now, the STOP bit is set at the correct timing to match the peripheral's expected sequence and avoid hanging.